### PR TITLE
fix: incorrect framework check

### DIFF
--- a/bridge.lua
+++ b/bridge.lua
@@ -15,6 +15,9 @@ Citizen.CreateThread(function()
     elseif Config.Framework == "qbcore" then
         QBCore = exports['qb-core']:GetCoreObject()
         print("[src-payphone] QBCore Framework initialized")
+    elseif Config.Framework == "qbox" then
+        if not QBX then return error("^4[src-payphone]^7 ^1QBX not found.^7 ^2Uncomment line in fxmanifest.lua^7") end
+        print("[src-payphone] QBox Framework initialized")
     else
         print("[src-payphone] Standalone mode initialized")
     end
@@ -35,6 +38,9 @@ Bridge.HasEnoughMoney = function(amount)
     elseif Config.Framework == "qbcore" then
         local Player = QBCore.Functions.GetPlayerData()
         return Player.money.cash >= amount
+    
+    elseif Config.Framework == "qbox" then
+        return QBX.PlayerData.money.cash >= amount
     else
         
         return true
@@ -53,6 +59,9 @@ Bridge.RemoveMoney = function(amount)
     elseif Config.Framework == "qbcore" then
         TriggerServerEvent('src-payphone:removeMoney', amount, 'qbcore')
         return true
+    elseif Config.Framework == "qbox" then
+        TriggerServerEvent('src-payphone:removeMoney', amount, 'qbox')
+        return true
     else
         TriggerServerEvent('src-payphone:removeMoney', amount, 'standalone')
         return true
@@ -64,6 +73,8 @@ Bridge.Notify = function(message, type)
         ESX.ShowNotification(message)
     elseif Config.Framework == "qbcore" then
         QBCore.Functions.Notify(message, type)
+    elseif Config.Framework == "qbox" then
+        exports.qbx_core:Notify(message, type)
     else
         lib.notify({
             title = 'Payphone',

--- a/bridge.lua
+++ b/bridge.lua
@@ -27,7 +27,7 @@ Bridge.HasEnoughMoney = function(amount)
         return true 
     end
     
-    if Config.Framework == "esx" or "esxnew" then
+    if Config.Framework == "esx" or Config.Framework == "esxnew" then
 
         local xPlayer = ESX.GetPlayerData()
         return xPlayer.money >= amount
@@ -47,7 +47,7 @@ Bridge.RemoveMoney = function(amount)
         return true
     end
     
-    if Config.Framework == "esx" or "esxnew" then
+    if Config.Framework == "esx" or Config.Framework == "esxnew" then
         TriggerServerEvent('src-payphone:removeMoney', amount, 'esx')
         return true
     elseif Config.Framework == "qbcore" then
@@ -60,7 +60,7 @@ Bridge.RemoveMoney = function(amount)
 end
 
 Bridge.Notify = function(message, type)
-    if Config.Framework == "esx" or "esxnew" then
+    if Config.Framework == "esx" or Config.Framework == "esxnew" then
         ESX.ShowNotification(message)
     elseif Config.Framework == "qbcore" then
         QBCore.Functions.Notify(message, type)

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = {}
 
 -- Framework Settings
-Config.Framework = "qbcore" -- Options: "qbcore", "esx", "standalone", "esxnew"
+Config.Framework = "qbcore" -- Options: "qbcore", "esx", "standalone", "esxnew", "qbox" -> IMPORTANT: QBOX requires uncommenting line in fxmanifest.lua
 Config.Target = "ox_target" -- Options: "ox_target", "qb-target"
 
 -- Call settings

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,6 +12,7 @@ shared_scripts {
 }
 
 client_scripts {
+    --'@qbx_core/modules/playerdata.lua',  -- QBox only
     'bridge.lua',
     'client.lua'
 }

--- a/server.lua
+++ b/server.lua
@@ -60,6 +60,11 @@ AddEventHandler('src-payphone:removeMoney', function(amount, framework)
                 Player.Functions.RemoveMoney('cash', amount, "payphone-call")
             end
         end
+    elseif framework == "qbox" then
+        local Player = exports.qbx_core:GetPlayer(source)
+        if Player then
+            return Player.Functions.RemoveMoney('cash', amount, "payphone-call")
+        end
     end
 end)
 

--- a/server.lua
+++ b/server.lua
@@ -46,7 +46,7 @@ RegisterNetEvent('src-payphone:removeMoney')
 AddEventHandler('src-payphone:removeMoney', function(amount, framework)
     local src = source
     
-    if framework == "esx" or "esxnew" then
+    if framework == "esx" or framework == "esxnew" then
         if ESX then
             local xPlayer = ESX.GetPlayerFromId(src)
             if xPlayer then


### PR DESCRIPTION
Fix incorrect framework check:

The earlier logic with an 'or' operator in the framework comparison was always returning true due to the second operand, "esxnew", being treated as a truthy string. This update corrects the comparison to properly verify if Config.Framework is set to either "esx" or "esxnew".